### PR TITLE
Handle ArgumentOutOfRangeException

### DIFF
--- a/mstranslator.js
+++ b/mstranslator.js
@@ -107,8 +107,10 @@ MsTranslator.prototype.call = function(path, params, fn) {
       //remove invalid BOM
       body = body.substring(1, body.length);
       try {
-        if (body.indexOf('ArgumentException:') === 1) {
-          fn(body, JSON.parse(body));
+        if (body.indexOf('ArgumentException:') === 1 ||
+          body.indexOf('ArgumentOutOfRangeException:') === 1) {
+
+          fn(new Error(body), JSON.parse(body));
         } else {
           fn(null, JSON.parse(body));
         }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "name": "mstranslator",
   "description": "Microsoft Translator API module for node.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/nanek/mstranslator.git"

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -104,4 +104,19 @@ describe('MsTranslator', function() {
     });
   });
 
+  it('handles an ArgumentOutOfRangeException', function(done) {
+    var params = {
+      text: 'whatever',
+      from: 'en',
+      to: 'easdfn'
+    };
+    translator.translate(params, function (err, data) {
+      assert.ok(
+        err.message.indexOf('ArgumentOutOfRangeException:') !== -1,
+        'An error reports the ArgumentOutOfRangeException.'
+      );
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Updated error handler to: 1) Check for ArgumentOutOfRangeException and 2) call back with an Error object instead of a string.

I did this because I was running into a case in which that error had occurred but because `translate` had not passed an error to a callback, my app just used the translation (which was an error message) without knowing anything was wrong.