### PR TITLE
Support strings with unescaped double quotes in array properties

### DIFF
--- a/mstranslator.js
+++ b/mstranslator.js
@@ -34,10 +34,19 @@ function MsTranslator(credentials, autoRefresh){
 
 module.exports = MsTranslator;
 
+function escapeDoubleQuotes (element) {
+  if(typeof element !== 'string' ) {
+    return element
+  }
+
+  return element.replace(/(^|[^\\])"/g, '$1\\"');
+}
 
 MsTranslator.prototype.printArray = function(arr)
 {
-  var arrval = arr.join('","');
+  var arrval = arr
+      .map(escapeDoubleQuotes)
+      .join('","');
   return '["' + arrval + '"]';
 }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -92,6 +92,18 @@ describe('MsTranslator', function() {
     });
   });
 
+  it.only('tests translateArray for texts with quotes', function(done) {
+    var texts = ['"start"', 'single "', 'escaped \\"'];
+    var params = { texts: texts , from: 'en', to: 'es', maxTranslations:5 };
+    translator.translateArray(params, function(err, data) {
+      assert.equal(Array.isArray(data), true);
+      assert.equal(data[0].TranslatedText, '«start»');
+      assert.equal(data[1].TranslatedText, 'solo"');
+      assert.equal(data[2].TranslatedText, 'escapó"');
+      done();
+    });
+  });
+
   it('tests translateArray2', function(done) {
     var texts = ['monkey', 'cow'];
     var params = { texts: texts , from: 'en', to: 'es', maxTranslations:5 };


### PR DESCRIPTION
This PR is supposed to make functions that takes arrays of text (e.g. `translateArray`) easier to use.

Currently this module have issue with `printArray` function which can result in malformed string that represents array.
This issue leads to next response from the Translator API
 ```
There was an error deserializing the object of type System.String[]. Encountered unexpected character 's'. 
```
instead of array with translations.

Function also should'n affect strings with already escaped quotes.

I supposed to use `JSON.stringify` instead of fixing `printArray`, but it leads to malformed strings when quotes are already escaped.

P.S.
As I can see now: tests for functions that supposed to work with arrays are using prepared strings.
Shouldn't they be converted to arrays also?

Best regards,
Andrii.