### PR TITLE
Feature 106783948 implement add translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
   [Microsoft Translator API Reference](http://msdn.microsoft.com/en-us/library/ff512404.aspx)
 
-  * addTranslation (not implemented)
+  * addTranslation
   * addTranslationArray (not implemented)
   * breakSentences (not working)
   * detect

--- a/mstranslator.js
+++ b/mstranslator.js
@@ -119,14 +119,18 @@ MsTranslator.prototype.call = function(path, params, fn) {
     res.on('end', function () {
       //remove invalid BOM
       body = body.substring(1, body.length);
+      var data = null;
+      if (body.length > 0) {
+        data = JSON.parse(body);
+      }
       try {
         var errMessages = errPatterns.filter(function(pattern) {
           return body.indexOf(pattern) === 1;
         });
         if (errMessages.length > 0) {
-          fn(new Error(body), JSON.parse(body));
+          fn(new Error(body), data);
         } else {
-          fn(null, JSON.parse(body));
+          fn(null, data);
         }
       } catch (e) {
         fn(e, null);
@@ -241,4 +245,10 @@ MsTranslator.prototype.translateArray = function(params, fn) {
 // http://msdn.microsoft.com/en-us/library/dn198370.aspx
 MsTranslator.prototype.translateArray2 = function(params, fn) {
   this.makeRequest('TranslateArray2', params, fn);
+};
+
+// AddTranslation Method
+// params { originalText, translatedText, from, to, user, options }
+MsTranslator.prototype.addTranslation = function(params, fn) {
+  this.makeRequest('AddTranslation', params, fn);
 };

--- a/mstranslator.js
+++ b/mstranslator.js
@@ -119,11 +119,11 @@ MsTranslator.prototype.call = function(path, params, fn) {
     res.on('end', function () {
       //remove invalid BOM
       body = body.substring(1, body.length);
-      var data = null;
-      if (body.length > 0) {
-        data = JSON.parse(body);
-      }
       try {
+        var data = null;
+        if (body.length > 0) {
+          data = JSON.parse(body);
+        }
         var errMessages = errPatterns.filter(function(pattern) {
           return body.indexOf(pattern) === 1;
         });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "name": "mstranslator",
   "description": "Microsoft Translator API module for node.js",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/nanek/mstranslator.git"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "mocha": "~2.3.0"
+    "chai": "3.4.0",
+    "mocha": "~2.3.0",
+    "underscore": "1.8.3"
   },
   "licenses": [
     {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,4 +1,8 @@
 var MsTranslator = require('../mstranslator');
+// http://nodejs.org/api/assert.html
+var assert       = require('assert');
+var expect       = require('chai').expect;
+var _            = require('underscore');
 
 var client_id=process.env.MSCLIENT_ID;
 var client_secret=process.env.MSCLIENT_SECRET;
@@ -11,9 +15,6 @@ if (!client_id || !client_secret) {
 var translator = new MsTranslator({client_id: client_id, client_secret: client_secret}, true);
 
 describe('MsTranslator', function() {
-  // http://nodejs.org/api/assert.html
-  var assert = require('assert');
-
   /*
   it('test breakSentences', function() {
     var text = encodeURIComponent("This is one sentence. The method will count this as the second sentences. Finally, the third sentence.");
@@ -113,6 +114,36 @@ describe('MsTranslator', function() {
       assert.equal(data[1].TranslatedText, 'vaca');
       assert.equal(data[1].Alignment , '0:2-0:3');
       done();
+    });
+  });
+
+  it('tests addTranslation', function(done) {
+    var addParams = {
+      originalText:   'Esto es una prueba',
+      translatedText: 'This is a quiz!',
+      from:           'es',
+      to:             'en',
+      user:           'testuser',
+    };
+
+    var getParams = {
+      text:   'Esto es una prueba',
+      from:           'es',
+      to:             'en',
+      maxTranslations: 200,
+    };
+
+    var params = { text: 'translate this.', from: 'en', to: 'es' };
+    translator.addTranslation(addParams, function(err, data) {
+      assert.equal(err, null);
+
+      // Added translation should now appear in results
+      translator.getTranslations(getParams, function(err, data) {
+        expect(data).to.have.property('Translations');
+        translations = _.pluck(data.Translations, 'TranslatedText');
+        expect(translations).to.contain('This is a quiz!');
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
@nanek @sandinmyjoints 

### What 
* Implements addTranslation
* Adds test for addTranslation
* Adds chai and underscore.js for those tests, lmk if you prefer not to use those
* Update version and README

### How to test
* Run tests

### Note
* I want to open a separate PR to add a check that returns an error if the response status is not 200, but I'm having trouble getting a non-200 response status for testing. Should I stub it out? Any other ideas?
