### PR TITLE
add a separate method that returns the url to a wave/mp3 stream

### DIFF
--- a/mstranslator.js
+++ b/mstranslator.js
@@ -282,7 +282,7 @@ MsTranslator.prototype.getTranslationsArray = function(params, fn) {
 };
 
 /**
- * Returns a string which is a URL to a wave or mp3 stream of the passed-in text
+ * Returns a wave or mp3 stream of the passed-in text
  * being spoken in the desired language.
  * @param {Object} params Parameters
  * @param {string} params.text A sentence or sentences of the specified language
@@ -296,6 +296,23 @@ MsTranslator.prototype.getTranslationsArray = function(params, fn) {
  */
 MsTranslator.prototype.speak = function(params, fn) {
   this.makeRequest('Speak', params, fn, 'call_speak');
+};
+
+/**
+ * Returns a string which is a URL to a wave or mp3 stream of the passed-in text
+ * being spoken in the desired language.
+ * @param {Object} params Parameters
+ * @param {string} params.text A sentence or sentences of the specified language
+ *   to be spoken for the wave stream. The size of the text to speak must not
+ *   exceed 2000 characters.
+ * @param {string} params.language Language code to speak the text in
+ * @param {string} [params.format=audio/wav] Content-type 'audio/wav' or
+ *   'audio/mp3'
+ * @param {Object} [params.options] Options
+ * @param {callback} fn callback
+ */
+MsTranslator.prototype.speakURL = function(params, fn) {
+  this.makeRequest('Speak', params, fn);
 };
 
 /**

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -74,6 +74,14 @@ describe('MsTranslator', function() {
     });
   });
 
+  it('tests speakURL', function(done) {
+    var params = { text: 'Muchas gracias.', language: 'es', format: 'audio/wav' };
+    translator.speakURL(params, function(err, data) {
+      assert.equal(typeof data, 'string');
+      done();
+    });
+  });
+
   it('tests translate', function(done) {
     var params = { text: 'translate this.', from: 'en', to: 'es' };
     translator.translate(params, function(err, data) {


### PR DESCRIPTION
added a separate method that returns a string(URL) to a wave/mp3 stream.

According to the msdn documentation, the /V2/Http.svc path returns only a wave/mp3 stream and the /V2/Ajax.svc path returns a URL to a wave/mp3.

/V2/Http.svc doc: https://msdn.microsoft.com/en-us/library/ff512420.aspx
/V2/Ajax.svc doc: https://msdn.microsoft.com/en-us/library/ff512405.aspx