### PR TITLE
Removed delete call for local variable.

### DIFF
--- a/mstranslator.js
+++ b/mstranslator.js
@@ -176,7 +176,6 @@ MsTranslator.prototype.call_speak = function(path, params, fn) {
         buf.copy(body, index, 0, buf.length);
         index += buf.length;
       });
-      delete(buffers);
       fn(null, body);
     });
   });


### PR DESCRIPTION
Fixes babel 6 abort:
mstranslator.js: Deleting local variable in strict mode (177:6)
Process finished with exit code 1