### PR TITLE
Ensure 200 when retreiving access token and expire current token if microsoft reports an error when using it

### DIFF
--- a/mstranslator.js
+++ b/mstranslator.js
@@ -174,6 +174,11 @@ MsTranslator.prototype.call = function(path, params, fn) {
           return body.indexOf(pattern) > -1;
         });
         if (errMessages.length > 0) {
+          // Expires the access token if the error contains the word 'token'.
+          // This could happen if the token somehow expired or is not valid.
+          if (body.indexOf('token') > -1) {
+            self.expires_at = Date.now();
+          }
           fn(new Error(body), data);
         } else {
           fn(null, data);

--- a/mstranslator.js
+++ b/mstranslator.js
@@ -114,12 +114,20 @@ MsTranslator.prototype.initialize_token = function(callback, noRefresh){
       data += chunk;
     });
     res.on('end', function () {
+      if (res.statusCode !== 200) {
+        if (callback !== undefined) {
+          callback(new Error('Received: ' + data +
+            ' when trying to retrieve a new access token. Status code: ' +
+            res.statusCode));
+        }
+        return;
+      }
       var keys;
       if (!self.useNewApi) {
         try {
           keys = JSON.parse(data);
         } catch (e) {
-          if(callback !== undefined) {
+          if (callback !== undefined) {
             callback(e);
           }
           return;
@@ -136,7 +144,7 @@ MsTranslator.prototype.initialize_token = function(callback, noRefresh){
       if (!noRefresh) {
         setTimeout(function() {self.initialize_token();}, self.expires_in);
       }
-      if(callback !== undefined) {
+      if (callback !== undefined) {
         callback(null, keys);
       }
     });

--- a/mstranslator.js
+++ b/mstranslator.js
@@ -150,11 +150,12 @@ MsTranslator.prototype.initialize_token = function(callback, noRefresh){
 };
 
 MsTranslator.prototype.call = function(path, params, fn) {
-  var settings = this.mstrans;
-  var errPatterns = this.ERR_PATTERNS;
-  settings.headers.Authorization = 'Bearer ' + this.access_token;
-  params = this.convertArrays(params);
-  settings.path= this.ajax_root + path + '?' + querystring.stringify(params);
+  var self = this;
+  var settings = self.mstrans;
+  var errPatterns = self.ERR_PATTERNS;
+  settings.headers.Authorization = 'Bearer ' + self.access_token;
+  params = self.convertArrays(params);
+  settings.path= self.ajax_root + path + '?' + querystring.stringify(params);
   var req = http.request(settings, function(res) {
     res.setEncoding('utf8');
     var body = '';

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -185,4 +185,26 @@ describe('MsTranslator', function () {
     });
   });
 
+  it('expires current token if token is bad', function (done) {
+    var params = {
+      text: 'Esto es una prueba',
+      from: 'en',
+      to: 'es'
+    };
+    translator.access_token = 'bad-token';
+    var expirationInOneMinute = Date.now() + 60000;
+    translator.expires_at = expirationInOneMinute;
+    translator.translate(params, function (err, data) {
+      assert.ok(
+        err.message.indexOf('token') !== -1,
+        'The error contains the word token'
+      );
+      assert.ok(
+        translator.expires_at < expirationInOneMinute,
+        'The access_token expiration was set to now'
+      );
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
@nanek 

# What/Why
* Throw error if retrieving an access token does not result in a 200. Not doing this can allow a bad access token to be cached and stick around until expiration.
* Forcibly expire the cached access token if sending a request to Microsoft reports that something is wrong with the token. This could be that the token has expired or that the token is invalid. We have seen both of these happen on a live site, though I believe throwing an error on a non-200 access token request will avoid sending translate requests with an invalid token.

# Testing
* The test suite passes with both old and new translator service credentials.
* I added a test for expiring a bad token
* As for the non-200 case, I couldn't figure out a way to get the translation service to return a non-200, so I think I would have to mock the `https` library. Let me know if you think I should do this.